### PR TITLE
Workaround for kubetest install error

### DIFF
--- a/v2/ci.py
+++ b/v2/ci.py
@@ -51,9 +51,12 @@ class CI(object):
     def _getKubetest(self):
         self.logging.info("Get Kubetest")
         if self.opts.kubetest_link == "":
+            # Clone repository using git and then install
+            # Workaround for https://github.com/kubernetes/test-infra/issues/14712
+            utils.clone_repo("https://github.com/kubernetes/test-infra", "master", "/tmp/test-infra")
             os.putenv("GO111MODULE", "on")
-            cmd = ["go", "get", "k8s.io/test-infra/kubetest"]
-            _, err, ret = utils.run_cmd(cmd, stderr=True)
+            cmd = ["go", "install", "./kubetest"]
+            _, err, ret = utils.run_cmd(cmd, stderr=True, cwd=/tmp/test-infra)
             if ret != 0:
                 self.logging.error("Failed to get kubetest binary with error: %s" % err)
                 raise Exception("Failed to get kubetest binary with errorr: %s" % err)

--- a/v2/ci.py
+++ b/v2/ci.py
@@ -6,6 +6,8 @@ import configargparse
 import subprocess
 import stat
 
+TESTINFRA_REPO_URL = "https://github.com/kubernetes/test-infra"
+
 p = configargparse.get_argument_parser()
 
 p.add("--repo-list", default="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list",
@@ -53,10 +55,10 @@ class CI(object):
         if self.opts.kubetest_link == "":
             # Clone repository using git and then install
             # Workaround for https://github.com/kubernetes/test-infra/issues/14712
-            utils.clone_repo("https://github.com/kubernetes/test-infra", "master", "/tmp/test-infra")
+            utils.clone_repo(TESTINFRA_REPO_URL, "master", "/tmp/test-infra")
             os.putenv("GO111MODULE", "on")
             cmd = ["go", "install", "./kubetest"]
-            _, err, ret = utils.run_cmd(cmd, stderr=True, cwd=/tmp/test-infra)
+            _, err, ret = utils.run_cmd(cmd, stderr=True, cwd="/tmp/test-infra")
             if ret != 0:
                 self.logging.error("Failed to get kubetest binary with error: %s" % err)
                 raise Exception("Failed to get kubetest binary with errorr: %s" % err)

--- a/v2/terraform_flannel.py
+++ b/v2/terraform_flannel.py
@@ -312,7 +312,7 @@ class Terraform_Flannel(ci.CI):
         self._copyFrom("/etc/kubernetes/tls/admin-key.pem","/etc/kubernetes/tls/admin-key.pem", linux_master, root=True)
 
         with open("/tmp/kubeconfig") as f:
-            content = yaml.load(f)
+            content = yaml.full_load(f)
         for cluster in content["clusters"]:
             cluster["cluster"]["server"] = "https://kubernetes"
         with open("/tmp/kubeconfig", "w") as f:


### PR DESCRIPTION
- Added workaround for kubetest install error, by cloning the repository first and then installing kubetest using go install
- Fixed a YAMLLoadWarning