### PR TITLE
Revert "Add depth flag to git clone"

### DIFF
--- a/v2/utils.py
+++ b/v2/utils.py
@@ -48,7 +48,7 @@ def run_cmd(cmd, timeout=50000, env=None, stdout=False,
 
 
 def clone_repo(repo, branch="master", dest_path=None):
-    cmd = ["git", "clone", "--depth=1", "--single-branch", "--branch", branch, repo]
+    cmd = ["git", "clone", "--single-branch", "--branch", branch, repo]
     if dest_path:
         cmd.append(dest_path)
     logging.info("Cloning git repo %s on branch %s in location %s" % (repo, branch, dest_path if not None else os.getcwd()))


### PR DESCRIPTION
This reverts commit 8a360f0c1e2e158226a5d7fd193841ac97970536.

--depth is actually causing a wrong k8s version to be built.